### PR TITLE
Create Transaction model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'turbolinks', '~> 5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'devise'
+gem 'enumerize'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    enumerize (2.3.1)
+      activesupport (>= 3.2)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
@@ -208,6 +210,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  enumerize
   listen (>= 3.0.5, < 3.2)
   mini_racer
   pg (~> 0.18.4)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,15 @@
+class Transaction < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+
+  validates :sender,
+            :receiver,
+            :source_currency,
+            :target_currency,
+            :amount,
+            :exchange_rate,
+            :status,
+            presence: true
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,4 +12,8 @@ class Transaction < ApplicationRecord
             :exchange_rate,
             :status,
             presence: true
+  
+  enumerize :source_currency, in: [:eur, :gbp, :usd]
+  enumerize :target_currency, in: [:eur, :gbp, :usd]
+  enumerize :status, in: [:scheduled, :finished, :failed], default: :scheduled
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, length: { in: 2..24 }
+
+  has_many :sent_transactions, class_name: "Transaction", foreign_key: "sender_id"
+  has_many :received_transactions, class_name: "Transaction", foreign_key: "receiver_id"
 end

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,2 +1,8 @@
-<h1>Transactions#index</h1>
-<p>Find me in app/views/transactions/index.html.erb</p>
+<h1>Transactions</h1>
+
+Name <%= current_user.name %>
+
+<br>
+
+Last transaction status:
+  <%= current_user.received_transactions.last.status_text %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  enumerize:
+    transaction:
+      status:
+        scheduled: "Scheduled"
+        finished: "Finished"
+        failed: "Failed"

--- a/db/migrate/20190713134554_create_transactions.rb
+++ b/db/migrate/20190713134554_create_transactions.rb
@@ -1,0 +1,17 @@
+class CreateTransactions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :transactions do |t|
+      t.integer :sender_id, index: true, null: false
+      t.integer :receiver_id, index: true, null: false
+      t.string :source_currency, null: false
+      t.string :target_currency, null: false
+      t.decimal :amount, precision: 15, scale: 2, null: false
+      t.decimal :exchange_rate, precision: 15, scale: 5, null: false
+      t.string :status, index: true, null: false
+      t.timestamps
+    end
+
+    add_foreign_key :transactions, :users, column: :sender_id
+    add_foreign_key :transactions, :users, column: :receiver_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_13_131319) do
+ActiveRecord::Schema.define(version: 2019_07_13_134554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "transactions", force: :cascade do |t|
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
+    t.string "source_currency", null: false
+    t.string "target_currency", null: false
+    t.decimal "amount", precision: 15, scale: 2, null: false
+    t.decimal "exchange_rate", precision: 15, scale: 5, null: false
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["receiver_id"], name: "index_transactions_on_receiver_id"
+    t.index ["sender_id"], name: "index_transactions_on_sender_id"
+    t.index ["status"], name: "index_transactions_on_status"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -28,4 +43,6 @@ ActiveRecord::Schema.define(version: 2019_07_13_131319) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "transactions", "users", column: "receiver_id"
+  add_foreign_key "transactions", "users", column: "sender_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,23 +6,33 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create!(
+default_bank_user = User.create!(
   :name => 'Basebank',
   :email => 'basebank@example.com',
   :password => 'password',
   :password_confirmation => 'password'
 )
 
-User.create!(
+mahmoud = User.create!(
   :name => 'Mahmoud',
   :email => 'mahmoud@example.com',
   :password => 'password',
   :password_confirmation => 'password'
 )
 
-User.create!(
+mathias = User.create!(
   :name => 'Mathias',
   :email => 'mathias@example.com',
   :password => 'password',
   :password_confirmation => 'password'
+)
+
+Transaction.create!(
+  sender: default_bank_user,
+  receiver: mahmoud,
+  source_currency: :usd,
+  target_currency: :eur,
+  amount: 500.53,
+  exchange_rate: 0.95432,
+  status: :finished
 )

--- a/test/fixtures/transactions.yml
+++ b/test/fixtures/transactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TransactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Description

Create a Transaction model to track all transfers between users.

## Changes

- Created `Transaction` model.
- Used `enumerize` gem to limit the values for the `source_currency `, `target_currency `, and `status` columns.
- Updated the DB seeds with a sample case of the new model.